### PR TITLE
Add feature AutoTrade and corresponding General Settings

### DIFF
--- a/E3Next/Processors/Casting.cs
+++ b/E3Next/Processors/Casting.cs
@@ -332,7 +332,7 @@ namespace E3Core.Processors
                                 bool navActive = MQ.Query<bool>("${Navigation.Active}");
                                 if (navActive)
                                 {
-                                    MQ.Cmd("/nav stop log=error");
+                                    MQ.Cmd("/nav pause");
                                 }
                                 MQ.Delay(300, "${Bool[!${Me.Moving}]}");
 
@@ -541,11 +541,15 @@ namespace E3Core.Processors
                         E3.ActionTaken = true;
                         //clear out the queues for the resist counters as they may have a few that lagged behind.
                         ClearResistChecks();
-                      
+
+                        if (MQ.Query<bool>($"${{Navigation.Paused}}")) MQ.Cmd("/nav pause");
+
                         return returnValue;
 
                     }
                     MQ.Write($"\arInvalid targetId for Casting. {targetID}");
+
+                    if (MQ.Query<bool>($"${{Navigation.Paused}}")) MQ.Cmd("/nav pause");
 
                     E3.ActionTaken = true;
                     return CastReturn.CAST_NOTARGET;
@@ -555,8 +559,8 @@ namespace E3Core.Processors
             {
                 PubServer.AddTopicMessage("${Casting}", String.Empty);
             }
-            
 
+            
         }
         private static bool NowCastReady()
         {

--- a/E3Next/Processors/DebuffDot.cs
+++ b/E3Next/Processors/DebuffDot.cs
@@ -390,6 +390,13 @@ namespace E3Core.Processors
                             continue;
                         }
                     }
+                    
+                    if (!MQ.Query<bool>($"${{Spell[{spell.CastName}].StacksTarget}}"))
+                    {
+                        //spell won't land based on stacking, move to next
+                        continue;
+                    }
+                    
                     var result = Casting.Cast(mobid, spell, Heals.SomeoneNeedsHealing);
                     if (result == CastReturn.CAST_INTERRUPTFORHEAL)
                     {

--- a/E3Next/Settings/CharacterSettings.cs
+++ b/E3Next/Settings/CharacterSettings.cs
@@ -37,7 +37,7 @@ namespace E3Core.Settings
         public string Misc_AnchorChar = string.Empty;
         public bool Misc_RemoveTorporAfterCombat = true;
         public bool Misc_AutoRez = false;
-
+        
         public bool Rogue_AutoHide = false;
         public bool Rogue_AutoEvade = false;
         public int Rogue_EvadePct = 0;
@@ -381,7 +381,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Anchor (Char to Anchor to)", "");
             section.Keys.AddKey("Remove Torpor After Combat", "On");
             section.Keys.AddKey("AutoRez", "Off");
-
+            
             newFile.Sections.AddSection("Assist Settings");
             section = newFile.Sections.GetSectionData("Assist Settings");
             section.Keys.AddKey("Assist Type (Melee/Ranged/Off)", "Melee");

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -58,6 +58,9 @@ namespace E3Core.Settings
         public Int32 Assists_LongTermDebuffRecast = 30;
         public Int32 Assists_ShortTermDebuffRecast = 5;
 
+        public String AutoTrade;
+        public List<string> AutoTradeValid = new List<string>() { "All", "Bots", "Guild", "Group", "Raid" };
+
         private System.DateTime _fileLastModified;
         private string _fileLastModifiedFileName;
         public GeneralSettings()
@@ -149,6 +152,12 @@ namespace E3Core.Settings
             LoadKeyData("Assists", "Acceptable Target Types", parsedData, ref Assists_AcceptableTargetTypes);
             LoadKeyData("Assists", "Long Term Debuff Recast(s)", parsedData, ref Assists_LongTermDebuffRecast);
             LoadKeyData("Assists", "Short Term Debuff Recast(s)", parsedData, ref Assists_ShortTermDebuffRecast);
+
+            LoadKeyData("AutoTrade", "AutoTrade (All,Bots,Guild,Group,Off,Raid)", parsedData, ref AutoTrade);
+            if (!AutoTradeValid.Contains(AutoTrade, StringComparer.OrdinalIgnoreCase))
+            {
+                AutoTrade = "Off";
+            }
         }
 
         public IniData CreateSettings()
@@ -226,6 +235,11 @@ namespace E3Core.Settings
             section.Keys.AddKey("Acceptable Target Types", "NPC,Pet");
             section.Keys.AddKey("Long Term Debuff Recast(s)", "30");
             section.Keys.AddKey("Short Term Debuff Recast(s)", "5");
+
+            //Trade
+            newFile.Sections.AddSection("Trade");
+            section = newFile.Sections.GetSectionData("Trade");
+            section.Keys.AddKey("AutoTrade (All,Bots,Guild,Group,Off,Raid)", "Off");
 
             string filename = GetSettingsFilePath("General Settings.ini");
             if (!System.IO.File.Exists(filename))


### PR DESCRIPTION
Fix for DebuffDot to check StacksTarget and bounce out early if spell won't land 
Fix for stopping nav when casting, will now resume nav if it was paused.