### PR TITLE
Add exclusion for selos song

### DIFF
--- a/E3Next/Classes/Bard.cs
+++ b/E3Next/Classes/Bard.cs
@@ -26,6 +26,7 @@ namespace E3Core.Classes
         private static Int64 _nextMelodyIfCheck = 0;
         private static Int64 _nextMelodyIfRefreshTimeInterval = 1000;
         private static bool _forceOverride = false;
+        private static string kSelosSongName = "Selo's Song of Travel";
 
         /// <summary>
         /// Initializes this instance.
@@ -78,6 +79,10 @@ namespace E3Core.Classes
 
             if (!_isInit) return;
             if (!_playingMelody || _forceOverride) return;
+            if (Spell.LoadedSpellsByName.ContainsKey(kSelosSongName)) {
+                Spell selosSpell = Spell.LoadedSpellsByName[kSelosSongName];
+                if (_songs.Contains(selosSpell)) return;
+            }
 
             //go through the ifs and see if we should change the melodies
             foreach(var melodyCheck in E3.CharacterSettings.Bard_MelodyIfs)


### PR DESCRIPTION
When using melodyIf such as: 

MelodyIf=Base/Ifs|NoCombat

And we have a travel melody setup such as
[travel Melody]
Song=Selo's Song of Travel/gem|4

And trying to have your bard cast Selos Song of Travel, you currently aren't able to do that. If you do the following commands:
/playmelody stop
/playmelody travel

What will happen is the bard tries to cast Selo's Song of Travel, but upon getting to the end, we will queue up the base melody. Then the bard will start playing the songs from `base` melody upon casting Selo's Song of Travel. The problem is it takes Selo's Song of Travel a little bit of time to make the bard invis. Since the bard isn't invis immediately, the bard will start playing the next song, which will take him out of invisibility.

Trying to do /playmelody stop will also just have the bard automatically find the melody to play... making it so you can't do Selo's Song of Travel unless you stop e3.

Idea here is to check the melody we're currently playing. If it has selos in the melody at all, then don't automatically switch melodies.
