### PR TITLE
update Zoning.CurrentZone on each zone change

### DIFF
--- a/E3Next/Processors/Zoning.cs
+++ b/E3Next/Processors/Zoning.cs
@@ -31,6 +31,8 @@ namespace E3Core.Processors
             {
                 CurrentZone = new Zone(zoneId);
                 ZoneLookup.Add(zoneId, new Zone(zoneId));
+            } else {
+                CurrentZone = ZoneLookup[zoneId];
             }
 
             TributeDataFile.ToggleTribute();


### PR DESCRIPTION
Right now, CurrentZone only changes if we don't have ZoneLookup[zoneId] currently set in the dictionary. This will set currentZone if we've already added zoneId to our lookup.