### PR TITLE
Add option to disable /interrupt on AssistOff

### DIFF
--- a/E3Next/Processors/Assist.cs
+++ b/E3Next/Processors/Assist.cs
@@ -408,9 +408,7 @@ namespace E3Core.Processors
         /// </summary>
         public static void AssistOff()
         {
-
-
-            if (Casting.IsCasting()) MQ.Cmd("/interrupt");
+            if (Casting.IsCasting() && E3.CharacterSettings.Misc_InterruptOnAssist) MQ.Cmd("/interrupt");
             if (MQ.Query<bool>("${Me.Combat}")) MQ.Cmd("/attack off");
             if (MQ.Query<bool>("${Me.AutoFire}"))
             {

--- a/E3Next/Settings/CharacterSettings.cs
+++ b/E3Next/Settings/CharacterSettings.cs
@@ -38,7 +38,8 @@ namespace E3Core.Settings
         public bool Misc_RemoveTorporAfterCombat = true;
         public bool Misc_AutoRez = false;
         public bool Misc_AutoForage = false;
-        
+        public bool Misc_InterruptOnAssist = true;
+
         public bool Rogue_AutoHide = false;
         public bool Rogue_AutoEvade = false;
         public int Rogue_EvadePct = 0;
@@ -214,8 +215,8 @@ namespace E3Core.Settings
             LoadKeyData("Misc", "Anchor (Char to Anchor to)", ParsedData, ref Misc_AnchorChar);
             LoadKeyData("Misc", "Remove Torpor After Combat", ParsedData, ref Misc_RemoveTorporAfterCombat);
             LoadKeyData("Misc", "AutoRez", ParsedData, ref Misc_AutoRez);
-            LoadKeyData("Misc", "Auto-Forage (On/Off)",ParsedData, ref Misc_AutoForage);
-
+            LoadKeyData("Misc", "Auto-Forage (On/Off)", ParsedData, ref Misc_AutoForage);
+            LoadKeyData("Misc", "Interrupt On Assist (On/Off)", ParsedData, ref Misc_InterruptOnAssist);
 
             LoadKeyData("Assist Settings", "Assist Type (Melee/Ranged/Off)", ParsedData, ref Assist_Type);
             LoadKeyData("Assist Settings", "Melee Stick Point", ParsedData, ref Assist_MeleeStickPoint);
@@ -376,6 +377,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Remove Torpor After Combat", "On");
             section.Keys.AddKey("AutoRez", "Off");
             section.Keys.AddKey("Auto-Forage (On/Off)", "Off");
+            section.Keys.AddKey("Interrupt On Assist (On/Off)", "On");
             
 
             newFile.Sections.AddSection("Assist Settings");


### PR DESCRIPTION
This is to avoid a handful of undesirable side effects such as casters dismounting or bard's skipping songs while twisting. The new setting defaults to On, which will preserve the old behavior for anyone who doesn't want this change.