### PR TITLE
fixed returns for bot buff targets that are not in your group or not …

### DIFF
--- a/E3Next/Processors/BuffCheck.cs
+++ b/E3Next/Processors/BuffCheck.cs
@@ -374,12 +374,12 @@ namespace E3Core.Processors
                         {
                             if (!_spawns.TryByName(target, out var spawn))
                             {
-                                return;
+                                continue;
                             }
 
                             if (!Basics.GroupMembers.Any() || !Basics.GroupMembers.Contains(spawn.ID))
                             {
-                                return;
+                                continue;
                             }
                         }
                     }


### PR DESCRIPTION
…in current spawns to continue on to next bot buff instead of bouncing out