### PR TITLE
Only tell toons in group to disband

### DIFF
--- a/E3Next/Processors/Basics.cs
+++ b/E3Next/Processors/Basics.cs
@@ -478,15 +478,19 @@ namespace E3Core.Processors
                 }
                 MQ.Cmd("/disband");
                 MQ.Cmd("/raiddisband");
-                E3.Bots.BroadcastCommand("/raiddisband");
-                E3.Bots.BroadcastCommand("/disband");
-
                 MQ.Delay(1500);
                 if (MQ.Query<int>("${Group}") > 0)
                 {
                     MQ.Delay(2000, "!${Group}");
                 }
 
+                foreach (var member in groupMembers)
+                {
+                    E3.Bots.BroadcastCommandToPerson(member,"/raiddisband");
+                    E3.Bots.BroadcastCommandToPerson(member,"/disband");
+                }
+                
+                MQ.Delay(1500);
                 foreach (var member in groupMembers)
                 {
                     MQ.Cmd($"/invite {member}");

--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -271,9 +271,6 @@ namespace E3Core.Processors
         }
         public static void DestroyCorpse(Spawn corpse)
         {
-            bool importantItem = false;
-            bool nodropImportantItem = false;
-
             MQ.Cmd("/loot");
             MQ.Delay(1000, "${Window[LootWnd].Open}");
             MQ.Delay(100);


### PR DESCRIPTION
Make it so when using savedgroups, only the toons in the group you're loading will /raiddisband and /disband.