### PR TITLE
Add wait to loot

### DIFF
--- a/E3Next/Processors/Assist.cs
+++ b/E3Next/Processors/Assist.cs
@@ -19,6 +19,8 @@ namespace E3Core.Processors
         public static Boolean IsAssisting = false;
         public static Int32 AssistTargetID = 0;
 
+        public static long LastAssistTimestamp = 0;
+
         private static Logging _log = E3.Log;
         private static IMQ MQ = E3.MQ;
         private static ISpawns _spawns = E3.Spawns;
@@ -650,6 +652,7 @@ namespace E3Core.Processors
         {
            EventProcessor.RegisterCommand("/assistme", (x) =>
            {
+            LastAssistTimestamp = Core.StopWatch.ElapsedMilliseconds;
                 //clear in case its not reset by other means
                 //or you want to attack in enrage
                 _assistIsEnraged = false;

--- a/E3Next/Processors/Assist.cs
+++ b/E3Next/Processors/Assist.cs
@@ -19,7 +19,7 @@ namespace E3Core.Processors
         public static Boolean IsAssisting = false;
         public static Int32 AssistTargetID = 0;
 
-        public static long LastAssistTimestamp = 0;
+        public static long LastAssistEndedTimestamp = 0;
 
         private static Logging _log = E3.Log;
         private static IMQ MQ = E3.MQ;
@@ -433,6 +433,7 @@ namespace E3Core.Processors
                 DebuffDot.Reset();
                 Burns.Reset();
             }
+            LastAssistEndedTimestamp = Core.StopWatch.ElapsedMilliseconds;
         }
 
         /// <summary>
@@ -652,7 +653,6 @@ namespace E3Core.Processors
         {
            EventProcessor.RegisterCommand("/assistme", (x) =>
            {
-            LastAssistTimestamp = Core.StopWatch.ElapsedMilliseconds;
                 //clear in case its not reset by other means
                 //or you want to attack in enrage
                 _assistIsEnraged = false;

--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -181,8 +181,8 @@ namespace E3Core.Processors
             if (!E3.CharacterSettings.Misc_AutoLootEnabled) return;
             if(!Assist.IsAssisting)
             {
-
-                if (!Basics.InCombat() || E3.GeneralSettings.Loot_LootInCombat)
+                long currentTimestamp = Core.StopWatch.ElapsedMilliseconds;
+                if ((!Basics.InCombat() && currentTimestamp - Assist.LastAssistTimestamp > E3.GeneralSettings.Loot_TimeToWaitAfterAssist) || E3.GeneralSettings.Loot_LootInCombat)
                 {
                     LootArea();
                 }

--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -182,7 +182,7 @@ namespace E3Core.Processors
             if(!Assist.IsAssisting)
             {
                 long currentTimestamp = Core.StopWatch.ElapsedMilliseconds;
-                if ((!Basics.InCombat() && currentTimestamp - Assist.LastAssistTimestamp > E3.GeneralSettings.Loot_TimeToWaitAfterAssist) || E3.GeneralSettings.Loot_LootInCombat)
+                if ((!Basics.InCombat() && currentTimestamp - Assist.LastAssistEndedTimestamp > E3.GeneralSettings.Loot_TimeToWaitAfterAssist) || E3.GeneralSettings.Loot_LootInCombat)
                 {
                     LootArea();
                 }

--- a/E3Next/Settings/CharacterSettings.cs
+++ b/E3Next/Settings/CharacterSettings.cs
@@ -455,7 +455,7 @@ namespace E3Core.Settings
             newFile.Sections.AddSection("Assist Settings");
             section = newFile.Sections.GetSectionData("Assist Settings");
             section.Keys.AddKey("Assist Type (Melee/Ranged/Off)", "Melee");
-            section.Keys.AddKey("Melee Stick Point", "Back");
+            section.Keys.AddKey("Melee Stick Point", "Behind");
             if (((CharacterClass & Class.Tank) == CharacterClass) || CharacterClass== Class.Ranger)
             {
                 section.Keys.AddKey("Taunt(On/Off)", "Off");

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -54,7 +54,7 @@ namespace E3Core.Settings
         public List<string> Loot_OnlyStackableAlwaysLoot = new List<string>();
         public Int32 Loot_OnlyStackableValueGreaterThanInCopper = 1;
         public Boolean Loot_OnlyStackableEnabled = false;
-        public Int32 Loot_TimeToWaitAfterAssist = 10000;
+        public Int32 Loot_TimeToWaitAfterAssist = 2000;
 
         public Boolean Assists_AutoAssistEnabled=false;
         public Int32 Assists_MaxEngagedDistance=250;
@@ -371,7 +371,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Nav Stop Distance", "10");
             section.Keys.AddKey("Anchor Distance Minimum", "15");
             section.Keys.AddKey("Anchor Distance Maximum", "150");
-            section.Keys.AddKey("Milliseconds till standing Still", "10000");
+            section.Keys.AddKey("Milliseconds till standing Still", "2000");
 
            
             if (!System.IO.File.Exists(filename))

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -54,6 +54,7 @@ namespace E3Core.Settings
         public List<string> Loot_OnlyStackableAlwaysLoot = new List<string>();
         public Int32 Loot_OnlyStackableValueGreaterThanInCopper = 1;
         public Boolean Loot_OnlyStackableEnabled = false;
+        public Int32 Loot_TimeToWaitAfterAssist = 0;
 
         public Boolean Assists_AutoAssistEnabled=false;
         public Int32 Assists_MaxEngagedDistance=250;
@@ -156,6 +157,7 @@ namespace E3Core.Settings
             }
 
             LoadKeyData("Loot", "Loot in Combat", parsedData, ref Loot_LootInCombat);
+            LoadKeyData("Loot", "Milliseconds To Wait To Loot", parsedData, ref Loot_TimeToWaitAfterAssist);
             LoadKeyData("Loot", "NumOfFreeSlotsOpen(1+)", parsedData, ref Loot_NumberOfFreeSlotsOpen);
             LoadKeyData("Loot", "Loot Only Stackable: Enable (On/Off)", parsedData, ref Loot_OnlyStackableEnabled);
             LoadKeyData("Loot", "Loot Only Stackable: With Value Greater Than Or Equal in Copper", parsedData, ref Loot_OnlyStackableValueGreaterThanInCopper);
@@ -309,6 +311,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Loot Link Channel","say");
 	        section.Keys.AddKey("Corpse Seek Radius","125");
             section.Keys.AddKey("Loot in Combat","TRUE");
+            section.Keys.AddKey("Milliseconds To Wait To Loot", "10000");
             section.Keys.AddKey("NumOfFreeSlotsOpen(1+)","0");
             section.Keys.AddKey("Loot Only Stackable: Enable (On/Off)", "Off");
             section.Keys.AddKey("Loot Only Stackable: With Value Greater Than Or Equal in Copper", "10000");

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -311,7 +311,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Loot Link Channel","say");
 	        section.Keys.AddKey("Corpse Seek Radius","125");
             section.Keys.AddKey("Loot in Combat","TRUE");
-            section.Keys.AddKey("Milliseconds To Wait To Loot", "10000");
+            section.Keys.AddKey("Milliseconds To Wait To Loot", "2000");
             section.Keys.AddKey("NumOfFreeSlotsOpen(1+)","0");
             section.Keys.AddKey("Loot Only Stackable: Enable (On/Off)", "Off");
             section.Keys.AddKey("Loot Only Stackable: With Value Greater Than Or Equal in Copper", "10000");
@@ -371,7 +371,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Nav Stop Distance", "10");
             section.Keys.AddKey("Anchor Distance Minimum", "15");
             section.Keys.AddKey("Anchor Distance Maximum", "150");
-            section.Keys.AddKey("Milliseconds till standing Still", "2000");
+            section.Keys.AddKey("Milliseconds till standing Still", "10000");
 
            
             if (!System.IO.File.Exists(filename))

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -54,7 +54,7 @@ namespace E3Core.Settings
         public List<string> Loot_OnlyStackableAlwaysLoot = new List<string>();
         public Int32 Loot_OnlyStackableValueGreaterThanInCopper = 1;
         public Boolean Loot_OnlyStackableEnabled = false;
-        public Int32 Loot_TimeToWaitAfterAssist = 0;
+        public Int32 Loot_TimeToWaitAfterAssist = 10000;
 
         public Boolean Assists_AutoAssistEnabled=false;
         public Int32 Assists_MaxEngagedDistance=250;


### PR DESCRIPTION
![testing](https://github.com/RekkasGit/E3Next/assets/1665885/47f069b2-5f1e-4e6c-8299-df1842c4e2de)

Setting a 40000 MS delay resulted in looting 38 seconds after mob died