### PR TITLE
Update e3util.cs to prevent dictionary crash on bufftoinfodict

### DIFF
--- a/E3Next/Utility/e3util.cs
+++ b/E3Next/Utility/e3util.cs
@@ -494,12 +494,8 @@ namespace E3Core.Utility
                     _buffInfoTempList.Clear();
                     string tstring = s.Substring(start, end - start);
                     StringsToNumbers(tstring, ',', _buffInfoTempList);
-                    if (result.ContainsKey((Int32)_buffInfoTempList[0])) {
-                        result[(Int32)_buffInfoTempList[0]] = Math.Max(result[(Int32)_buffInfoTempList[0]], _buffInfoTempList[1]);
-                    } else {
-                        result.Add((Int32)_buffInfoTempList[0], _buffInfoTempList[1]);
-                    }
-					start = end + 1;
+                    result[(int)_buffInfoTempList[0]] = _buffInfoTempList[1];
+		    start = end + 1;
 				}
 				end++;
 			}

--- a/E3Next/Utility/e3util.cs
+++ b/E3Next/Utility/e3util.cs
@@ -494,8 +494,11 @@ namespace E3Core.Utility
                     _buffInfoTempList.Clear();
                     string tstring = s.Substring(start, end - start);
                     StringsToNumbers(tstring, ',', _buffInfoTempList);
-                    result.Add((Int32)_buffInfoTempList[0], _buffInfoTempList[1]);
-
+                    if (result.ContainsKey((Int32)_buffInfoTempList[0])) {
+                        result[(Int32)_buffInfoTempList[0]] = Math.Max(_buffInfoTempList[0], _buffInfoTempList[1]);
+                    } else {
+                        result.Add((Int32)_buffInfoTempList[0], _buffInfoTempList[1]);
+                    }
 					start = end + 1;
 				}
 				end++;

--- a/E3Next/Utility/e3util.cs
+++ b/E3Next/Utility/e3util.cs
@@ -495,7 +495,7 @@ namespace E3Core.Utility
                     string tstring = s.Substring(start, end - start);
                     StringsToNumbers(tstring, ',', _buffInfoTempList);
                     if (result.ContainsKey((Int32)_buffInfoTempList[0])) {
-                        result[(Int32)_buffInfoTempList[0]] = Math.Max(_buffInfoTempList[0], _buffInfoTempList[1]);
+                        result[(Int32)_buffInfoTempList[0]] = Math.Max(result[(Int32)_buffInfoTempList[0]], _buffInfoTempList[1]);
                     } else {
                         result.Add((Int32)_buffInfoTempList[0], _buffInfoTempList[1]);
                     }


### PR DESCRIPTION
Use guarding for c# dictionary

convo:
https://discord.com/channels/548643730714918913/1024676514119290901/1197091919021490287

I'm not exactly sure what the true fix is here, but this can at least prevent crashing if we're being given buff lists with duplicate keys. It's essentially just a dumb reduce that'll condense duplicates and use the Max of durations as the value.