### PR TITLE
Update GeneralSettings.cs

### DIFF
--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -302,7 +302,7 @@ namespace E3Core.Settings
 
             newFile.Sections.AddSection("General");
             var section = newFile.Sections.GetSectionData("General");
-            section.Keys.AddKey("AutoMedBreak PctMana", "0");
+            section.Keys.AddKey("AutoMedBreak PctMana", "70");
             section.Keys.AddKey("NetworkMethod", "EQBC");
             section.Keys.AddKey("E3NetworkAddPathToMonitor", "");
             section.Keys.AddKey("Network Default Broadcast (Group,All,AllInZoneOrRaid)", "Group");


### PR DESCRIPTION
Changed AutoMedBreak from 0 to 70. 
This only affects new install / deleted General_Settings But enables MedBreaks below 70, 
as 0 breaks character ini and they never start to Medbreak