### PR TITLE
Fix looting/destroying items

### DIFF
--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -556,6 +556,7 @@ namespace E3Core.Processors
 
                 MQ.Delay(1000, $"${{Corpse.Item[{i}].ID}}");
 
+                var itemId = MQ.Query<int>($"${{Corpse.Item[{i}].ID}}");
                 string corpseItem = MQ.Query<string>($"${{Corpse.Item[{i}].Name}}");
                 bool stackable = MQ.Query<bool>($"${{Corpse.Item[{i}].Stackable}}");
                 bool nodrop = MQ.Query<bool>($"${{Corpse.Item[{i}].NoDrop}}");
@@ -567,11 +568,13 @@ namespace E3Core.Processors
                 //destroy things we don't like
 				if (LootDataFile.Destroy.Contains(corpseItem))
 				{
-					//lets loot it if we can!
-					MQ.Cmd($"/nomodkey /shift /itemnotify loot{i} leftmouseup", 300);
+                    e3util.ClearCursor();
+
+                    //lets loot it if we can!
+                    MQ.Cmd($"/nomodkey /shift /itemnotify loot{i} leftmouseup", 300);
 					MQ.Delay(1000, "${Cursor.ID}");
-					Int32 cursorid = MQ.Query<Int32>("${Cursor.ID}");
-					if (cursorid > 0)
+                    var cursorid = MQ.Query<int>("${Cursor.ID}");
+                    if (cursorid == itemId)
 					{
 						E3.Bots.Broadcast($"Deleting from corpse [{MQ.Query<string>("${Cursor}")}]");
 						//have it on our cursor, lets destroy
@@ -580,6 +583,10 @@ namespace E3Core.Processors
 						MQ.Delay(1000, "${If[${Cursor.ID},FALSE,TRUE]}");
 
 					}
+                    else
+                    {
+                        e3util.ClearCursor();
+                    }
 					continue;
 				}
 


### PR DESCRIPTION
Currently there is a chance to destroy the incorrect item if it is clicked before an item that's supposed to be getting destroyed is clicked during looting. 

This adds a check to make sure the cursor id matches the id of the item that's supposed to be destroyed. It also clears the cursor before looting, or if the item on the cursor doesn't match what we're trying to destroy.

I'm pretty sure it destroyed an item of mine earlier without this change, with this change I wasn't able to get it to destroy an incorrect item.