### PR TITLE
Added loot range check during looting

### DIFF
--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -278,6 +278,13 @@ namespace E3Core.Processors
                         if (Basics.InCombat()) return;
                     }
 
+
+                    if (MQ.Query<double>($"${{Spawn[id {c.ID}].Distance3D}}") > E3.GeneralSettings.Loot_CorpseSeekRadius*2)
+                    {
+                        E3.Bots.Broadcast($"\arSkipping corpse: {c.ID} because of distance: ${{Spawn[id {c.ID}].Distance3D}}");
+                        continue;
+                    }
+
                     Casting.TrueTarget(c.ID);
                     MQ.Delay(2000, "${Target.ID}");
                    


### PR DESCRIPTION
This adds a loot range check to make sure we aren't over 2 times the loot radius from the corpse we're trying to loot (since we were once in range, 2 times the radius seems good?). This ensures that if we kill a big pile of mobs at the same time and move to another, looting won't try to continue at the first pile.