### PR TITLE
Fix multiple group members trying to loot the same corpse

### DIFF
--- a/E3Next/Processors/Loot.cs
+++ b/E3Next/Processors/Loot.cs
@@ -75,6 +75,7 @@ namespace E3Core.Processors
                 } 
             });
 
+
             EventProcessor.RegisterCommand("/looton", (x) =>
             {
                 
@@ -266,9 +267,10 @@ namespace E3Core.Processors
 
                 foreach (var c in corpses)
                 {
-					
-					//allow eq time to send the message to us
-					e3util.YieldToEQ();
+                    E3.Bots.BroadcastLootingCorpse(c.ID, true);
+
+                    //allow eq time to send the message to us
+                    e3util.YieldToEQ();
                     if (e3util.IsShuttingDown() || E3.IsPaused()) return;
                     EventProcessor.ProcessEventsInQueues("/lootoff");
 					EventProcessor.ProcessEventsInQueues("/assistme");
@@ -276,6 +278,14 @@ namespace E3Core.Processors
                     if (!E3.GeneralSettings.Loot_LootInCombat)
                     {
                         if (Basics.InCombat()) return;
+                    }
+
+                    EventProcessor.ProcessEventsInQueues("Looting");
+                    if (E3.Bots.IsGroupLooting(c.ID))
+                    {
+                        MQ.Write($"\arCorpse {c.ID} is already being looted!");
+                        E3.Bots.BroadcastLootingCorpse(c.ID, false);
+                        continue;
                     }
 
 
@@ -301,7 +311,8 @@ namespace E3Core.Processors
 
                         MQ.Delay(300);
                     }
-                    
+                    E3.Bots.BroadcastLootingCorpse(c.ID, false);
+
                 }
 
                 E3.Bots.Broadcast("\agFinished looting area");

--- a/E3Next/Server/SharedDataClient.cs
+++ b/E3Next/Server/SharedDataClient.cs
@@ -301,7 +301,8 @@ namespace E3Core.Server
 					subSocket.Subscribe("BroadCastMessage");
 					subSocket.Subscribe("BroadCastMessageZone");
 					subSocket.Subscribe("${Me."); //all Me stuff should be subscribed to
-					MQ.Write("\agShared Data Client: Connecting to user:" + user + " on port:" + port + " server:"+serverName); ;
+                    subSocket.Subscribe("Looting");
+                    MQ.Write("\agShared Data Client: Connecting to user:" + user + " on port:" + port + " server:"+serverName); ;
 
 					while (Core.IsProcessing && E3.NetMQ_SharedDataServerThradRun)
 					{


### PR DESCRIPTION
This adds a `Looting` topic, broadcasts corpse ids to it, and makes sure no other group members are already looting the corpse before beginning to loot.