### PR TITLE
Added /notarget when used won't switch targets.

### DIFF
--- a/E3Next/Data/Spell.cs
+++ b/E3Next/Data/Spell.cs
@@ -201,6 +201,10 @@ namespace E3Core.Data
                     {
                         NoBurn = true;
                     }
+                    else if (value.Equals("NoTarget", StringComparison.OrdinalIgnoreCase))
+                    {
+                        NoTarget = true;
+                    }
                     else if (value.Equals("NoAggro", StringComparison.OrdinalIgnoreCase))
                     {
                         NoAggro = true;
@@ -750,6 +754,7 @@ namespace E3Core.Data
         public String Reagent = String.Empty;
         public Boolean ItemMustEquip;
         public Boolean NoBurn;
+        public Boolean NoTarget;
         public Boolean NoAggro;
         public Int32 Mode;
         public Boolean Rotate;

--- a/E3Next/Processors/Casting.cs
+++ b/E3Next/Processors/Casting.cs
@@ -47,6 +47,10 @@ namespace E3Core.Processors
 			}
 			try
 			{
+				if (spell.NoTarget)
+				{
+                    targetID = 0;
+                }
 
 				if (targetID == 0)
 				{


### PR DESCRIPTION
There are times as a tank when you have an item clicky or a spell that doesn't require target and you would like to stay on your current target. This allows you to trigger spell or item with out switching to the character that is being monitored.

`Important Heal=Ancient Frozen Blue Band/HealPct|100/NoTarget`
