### PR TITLE
Fix for one-song melody's

### DIFF
--- a/E3Next/Classes/Bard.cs
+++ b/E3Next/Classes/Bard.cs
@@ -224,9 +224,9 @@ namespace E3Core.Classes
 			Int32 trycounter = 0;
     		pickASong:
 			songToPlay = _songs.Dequeue();
-	        trycounter++;
+
 			//we have gone through all the songs and not found a valid one to use, kick out
-			if (trycounter > _songs.Count)
+			if (trycounter++ > _songs.Count)
 			{
 				_songs.Enqueue(songToPlay);//place song back
 				return;


### PR DESCRIPTION
When using the loot-commander branch I had the issue with a melody containing only one song (in my case its just Selo's Travel Song for invis).
I use "/playmelody invis force" to run it but that was no longer working.

I believe this code block here in Bard.cs is the issue.

A melody with 1 song will always trigger the if-block since trycounter (1) is > songs count (0) after dequeue.

Tested this with my bard and my melodys including the invis one were working again.