### PR TITLE
Bando rework; as to not have to input individual weapon names. 

### DIFF
--- a/E3Next/Processors/BuffCheck.cs
+++ b/E3Next/Processors/BuffCheck.cs
@@ -1628,6 +1628,7 @@ namespace E3Core.Processors
 			if (!e3util.ShouldCheck(ref _nextBandoBuffCheck, _nextBandoBuffCheckInterval)) return;
 
 			if (!E3.CharacterSettings.BandoBuff_Enabled) return;
+			if (E3.CharacterSettings.BandoBuff_ExceptionZones.Contains(Zoning.CurrentZone.ShortName)) return;
 			if (E3.CharacterSettings.BandoBuff_Enabled && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName)) return;
 			if (!String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff)) return;
 			if (!String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName)) return;

--- a/E3Next/Processors/BuffCheck.cs
+++ b/E3Next/Processors/BuffCheck.cs
@@ -1628,15 +1628,14 @@ namespace E3Core.Processors
 			if (!e3util.ShouldCheck(ref _nextBandoBuffCheck, _nextBandoBuffCheckInterval)) return;
 
 			if (!E3.CharacterSettings.BandoBuff_Enabled) return;
-			if (String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BuffName)) return;
-			if (String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_Primary)) return;
-			if (String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_PrimaryWithoutBuff)) return;
-			if (String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoName)) return;
-			if (String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff)) return;
+			if (E3.CharacterSettings.BandoBuff_Enabled && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName)) return;
+			if (!String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff)) return;
+			if (!String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_BandoName) && String.IsNullOrWhiteSpace(E3.CharacterSettings.BandoBuff_DebuffName)) return;
 
 			bool hasBuff = true;
+            bool buffWillStack = MQ.Query<bool>($"${{Spell[{E3.CharacterSettings.BandoBuff_BuffName}].WillLand}}");
 
-			if (E3.CharacterSettings.BandoBuff_BuffName != String.Empty)
+            if (E3.CharacterSettings.BandoBuff_BuffName != String.Empty && buffWillStack)
 			{
 				hasBuff = MQ.Query<bool>($"${{Bool[${{Me.Buff[{E3.CharacterSettings.BandoBuff_BuffName}]}}]}}");
 				if (!hasBuff)
@@ -1661,21 +1660,25 @@ namespace E3Core.Processors
 				}
 			}
 
-			//we have the debuff or we have the buff.
-			string primaryName = MQ.Query<String>("${Me.Inventory[13]}");
-			string secondaryName = MQ.Query<String>("${Me.Inventory[14]}");
-			if (hasBuff)
+
+			bool bandoDefaultName = MQ.Query<bool>($"${{Me.Bandolier[{E3.CharacterSettings.BandoBuff_BandoName}].Active}}");
+			bool bandoWithoutBuffName = MQ.Query<bool>($"${{Me.Bandolier[{E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff}].Active}}");
+			bool bandoWithoutDeBuffName = MQ.Query<bool>($"${{Me.Bandolier[{E3.CharacterSettings.BandoBuff_BandoNameWithoutDeBuff}].Active}}");
+
+            if (hasBuff)
 			{
-				if (!(String.Equals(primaryName, E3.CharacterSettings.BandoBuff_Primary, StringComparison.OrdinalIgnoreCase) && String.Equals(secondaryName, E3.CharacterSettings.BandoBuff_Secondary, StringComparison.OrdinalIgnoreCase)))
-				{
+				if (!bandoDefaultName)
+
+                {
 					E3.Bots.Broadcast($"Swapping to {E3.CharacterSettings.BandoBuff_BandoName}");
 					MQ.Cmd($"/bando activate {E3.CharacterSettings.BandoBuff_BandoName}");
 				}
 			}
 			else
 			{
-				if (!(String.Equals(primaryName, E3.CharacterSettings.BandoBuff_PrimaryWithoutBuff, StringComparison.OrdinalIgnoreCase) && String.Equals(secondaryName, E3.CharacterSettings.BandoBuff_SecondaryWithoutBuff, StringComparison.OrdinalIgnoreCase)))
-				{
+				if (!bandoWithoutBuffName)
+
+                {
 					E3.Bots.Broadcast($"Swapping to {E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff}");
 
 					MQ.Cmd($"/bando activate {E3.CharacterSettings.BandoBuff_BandoNameWithoutBuff}");

--- a/E3Next/Settings/CharacterSettings.cs
+++ b/E3Next/Settings/CharacterSettings.cs
@@ -142,16 +142,13 @@ namespace E3Core.Settings
         public bool BandoBuff_Enabled = false;
 		public string BandoBuff_BuffName = String.Empty;
 		public string BandoBuff_DebuffName = String.Empty;
-		//public string BandoBuff_Primary = String.Empty;
-		//public string BandoBuff_Secondary = String.Empty;
-		//public string BandoBuff_PrimaryWithoutBuff = String.Empty;
-		//public string BandoBuff_SecondaryWithoutBuff = String.Empty;
 	    public string BandoBuff_BandoName = String.Empty;
 		public string BandoBuff_BandoNameWithoutBuff = String.Empty;
-		public string BandoBuff_BandoNameWithoutDeBuff = String.Empty;
+        public string BandoBuff_BandoNameWithoutDeBuff = String.Empty;
+        public HashSet<string> BandoBuff_ExceptionZones = new HashSet<string> {};
 
-		//manastone
-		public bool Manastone_Enabled = true;
+        //manastone
+        public bool Manastone_Enabled = true;
         public bool Manastone_OverrideGeneralSettings = false;
         public Int32 ManaStone_NumberOfClicksPerLoop = 40;
         public Int32 ManaStone_NumberOfLoops = 25;
@@ -357,14 +354,21 @@ namespace E3Core.Settings
 			LoadKeyData("Bando Buff", "Enabled", ParsedData, ref BandoBuff_Enabled);
 			LoadKeyData("Bando Buff", "DebuffName", ParsedData, ref BandoBuff_DebuffName);
 			LoadKeyData("Bando Buff", "BuffName", ParsedData, ref BandoBuff_BuffName);
-			//LoadKeyData("Bando Buff", "PrimaryWithBuff", ParsedData, ref BandoBuff_Primary);
-			//LoadKeyData("Bando Buff", "SecondaryWithBuff", ParsedData, ref BandoBuff_Secondary);
-			//LoadKeyData("Bando Buff", "PrimaryWithoutBuff", ParsedData, ref BandoBuff_PrimaryWithoutBuff);
-			//LoadKeyData("Bando Buff", "SecondaryWithoutBuff", ParsedData, ref BandoBuff_SecondaryWithoutBuff);
 			LoadKeyData("Bando Buff", "BandoNameDefault", ParsedData, ref BandoBuff_BandoName);
 			LoadKeyData("Bando Buff", "BandoNameWithoutBuff", ParsedData, ref BandoBuff_BandoNameWithoutBuff);
 			LoadKeyData("Bando Buff", "BandoNameWithoutDeBuff", ParsedData, ref BandoBuff_BandoNameWithoutDeBuff);
-			LoadKeyData("Assist Settings", "Assist Type (Melee/Ranged/Off)", ParsedData, ref Assist_Type);
+            List<string> bandozoneList = new List<string>();
+            LoadKeyData("Bando Buff", "ExceptionZone", ParsedData, bandozoneList);
+
+            foreach (var bandozone in bandozoneList)
+            {
+                if (!BandoBuff_ExceptionZones.Contains(bandozone))
+                {
+                    BandoBuff_ExceptionZones.Add(bandozone);
+                }
+            }
+
+            LoadKeyData("Assist Settings", "Assist Type (Melee/Ranged/Off)", ParsedData, ref Assist_Type);
             LoadKeyData("Assist Settings", "Melee Stick Point", ParsedData, ref Assist_MeleeStickPoint);
             LoadKeyData("Assist Settings", "Taunt(On/Off)", ParsedData, ref Assist_TauntEnabled);
             LoadKeyData("Assist Settings", "SmartTaunt(On/Off)", ParsedData, ref Assist_SmartTaunt);
@@ -878,10 +882,10 @@ namespace E3Core.Settings
             section.Keys.AddKey("BandoNameDefault");
 			section.Keys.AddKey("BandoNameWithoutBuff", "");
 			section.Keys.AddKey("BandoNameWithoutDeBuff", "");
+            section.Keys.AddKey("ExceptionZone", "poknowledge");
+            section.Keys.AddKey("ExceptionZone", "guildlobby");
 
-
-
-			newFile.Sections.AddSection("Startup Commands");
+            newFile.Sections.AddSection("Startup Commands");
 			section = newFile.Sections.GetSectionData("Startup Commands");
 			section.Keys.AddKey("Command", "");
 

--- a/E3Next/Settings/CharacterSettings.cs
+++ b/E3Next/Settings/CharacterSettings.cs
@@ -142,10 +142,10 @@ namespace E3Core.Settings
         public bool BandoBuff_Enabled = false;
 		public string BandoBuff_BuffName = String.Empty;
 		public string BandoBuff_DebuffName = String.Empty;
-		public string BandoBuff_Primary = String.Empty;
-		public string BandoBuff_Secondary = String.Empty;
-		public string BandoBuff_PrimaryWithoutBuff = String.Empty;
-		public string BandoBuff_SecondaryWithoutBuff = String.Empty;
+		//public string BandoBuff_Primary = String.Empty;
+		//public string BandoBuff_Secondary = String.Empty;
+		//public string BandoBuff_PrimaryWithoutBuff = String.Empty;
+		//public string BandoBuff_SecondaryWithoutBuff = String.Empty;
 	    public string BandoBuff_BandoName = String.Empty;
 		public string BandoBuff_BandoNameWithoutBuff = String.Empty;
 		public string BandoBuff_BandoNameWithoutDeBuff = String.Empty;
@@ -357,11 +357,11 @@ namespace E3Core.Settings
 			LoadKeyData("Bando Buff", "Enabled", ParsedData, ref BandoBuff_Enabled);
 			LoadKeyData("Bando Buff", "DebuffName", ParsedData, ref BandoBuff_DebuffName);
 			LoadKeyData("Bando Buff", "BuffName", ParsedData, ref BandoBuff_BuffName);
-			LoadKeyData("Bando Buff", "PrimaryWithBuff", ParsedData, ref BandoBuff_Primary);
-			LoadKeyData("Bando Buff", "SecondaryWithBuff", ParsedData, ref BandoBuff_Secondary);
-			LoadKeyData("Bando Buff", "PrimaryWithoutBuff", ParsedData, ref BandoBuff_PrimaryWithoutBuff);
-			LoadKeyData("Bando Buff", "SecondaryWithoutBuff", ParsedData, ref BandoBuff_SecondaryWithoutBuff);
-			LoadKeyData("Bando Buff", "BandoNameWithBuff", ParsedData, ref BandoBuff_BandoName);
+			//LoadKeyData("Bando Buff", "PrimaryWithBuff", ParsedData, ref BandoBuff_Primary);
+			//LoadKeyData("Bando Buff", "SecondaryWithBuff", ParsedData, ref BandoBuff_Secondary);
+			//LoadKeyData("Bando Buff", "PrimaryWithoutBuff", ParsedData, ref BandoBuff_PrimaryWithoutBuff);
+			//LoadKeyData("Bando Buff", "SecondaryWithoutBuff", ParsedData, ref BandoBuff_SecondaryWithoutBuff);
+			LoadKeyData("Bando Buff", "BandoNameDefault", ParsedData, ref BandoBuff_BandoName);
 			LoadKeyData("Bando Buff", "BandoNameWithoutBuff", ParsedData, ref BandoBuff_BandoNameWithoutBuff);
 			LoadKeyData("Bando Buff", "BandoNameWithoutDeBuff", ParsedData, ref BandoBuff_BandoNameWithoutDeBuff);
 			LoadKeyData("Assist Settings", "Assist Type (Melee/Ranged/Off)", ParsedData, ref Assist_Type);
@@ -875,11 +875,7 @@ namespace E3Core.Settings
             section.Keys.AddKey("Enabled", "Off");
 			section.Keys.AddKey("BuffName", "");
 			section.Keys.AddKey("DebuffName", "");
-			section.Keys.AddKey("PrimaryWithBuff", "");
-			section.Keys.AddKey("SecondaryWithBuff", "");
-			section.Keys.AddKey("PrimaryWithoutBuff", "");
-			section.Keys.AddKey("SecondaryWithoutBuff", "");
-			section.Keys.AddKey("BandoNameWithBuff", "");
+            section.Keys.AddKey("BandoNameDefault");
 			section.Keys.AddKey("BandoNameWithoutBuff", "");
 			section.Keys.AddKey("BandoNameWithoutDeBuff", "");
 


### PR DESCRIPTION
I also added the capability to check if the buff will land. In testing a few times I received a buff that would overwrite and block the weapon proc. This is will stop from switching to withoutbuff bando when it isn't needed.

Here is what the new ini file section looks like.
```
[Bando Buff]
Enabled=On
BuffName=Avatar
DebuffName=
BandoNameWithoutBuff=Avatar
BandoNameWithoutDeBuff=
BandoNameDefault=2H
ExceptionZone=poknowledge
ExceptionZone=guildlobby
```
or with both
```
[Bando Buff]
Enabled=On
BuffName=Avatar
DebuffName=Tashani
BandoNameWithoutBuff=Avatar
BandoNameWithoutDeBuff=Debuff
BandoNameDefault=DPS
ExceptionZone=poknowledge
ExceptionZone=guildlobby
```