### PR TITLE
[RFC] Add general setting for delays after short and long casts

### DIFF
--- a/E3Next/Processors/Casting.cs
+++ b/E3Next/Processors/Casting.cs
@@ -532,7 +532,7 @@ namespace E3Core.Processors
 									MQ.Cmd($"/casting \"{spell.CastName}|{spell.SpellGem}\"");
 									if (spell.MyCastTime > 500)
 									{
-										MQ.Delay(500);
+										MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 									}
 								}
 								else
@@ -548,11 +548,11 @@ namespace E3Core.Processors
 
 										if (spell.MyCastTime > 500)
 										{
-											MQ.Delay(500);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 										}
 										else
 										{
-											MQ.Delay(300);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterShortCastTime);
 										}
 									}
 									else
@@ -566,7 +566,7 @@ namespace E3Core.Processors
 										UpdateItemInCooldown(spell);
 										if (spell.MyCastTime > 500)
 										{
-											MQ.Delay(500);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 										}
 									}
 								}
@@ -581,7 +581,7 @@ namespace E3Core.Processors
 									MQ.Cmd($"/casting \"{spell.CastName}|{spell.SpellGem}\" \"-targetid|{targetID}\"");
 									if (spell.MyCastTime > 500)
 									{
-										MQ.Delay(500);
+										MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 									}
 								}
 								else
@@ -596,11 +596,11 @@ namespace E3Core.Processors
 
 										if (spell.MyCastTime > 500)
 										{
-											MQ.Delay(500);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 										}
 										else
 										{
-											MQ.Delay(300);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterShortCastTime);
 										}
 									}
 									else
@@ -611,7 +611,7 @@ namespace E3Core.Processors
 										UpdateItemInCooldown(spell);
 										if (spell.MyCastTime > 500)
 										{
-											MQ.Delay(500);
+											MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 										}
 									}
 								}
@@ -944,7 +944,7 @@ namespace E3Core.Processors
 							if (IsCasting())
 							{
 								//on live the cast window comes up on a missed note, so we check just for a bit to make sure so we can recast. 
-								MQ.Delay(500);
+								MQ.Delay(E3.GeneralSettings.General_DelayAfterLongCastTime);
 							}
 						}
 					}

--- a/E3Next/Settings/GeneralSettings.cs
+++ b/E3Next/Settings/GeneralSettings.cs
@@ -32,6 +32,8 @@ namespace E3Core.Settings
 		public bool General_CureWhileNavigating = true;
         public bool General_BeepNotifications = true;
         public bool General_LazarusManaRecovery = true;
+        public Int32 General_DelayAfterShortCastTime = 300;
+        public Int32 General_DelayAfterLongCastTime = 500;
 
         public string General_Networking_ExternalIPToQueryForLocal = "8.8.8.8";
         public string General_Networking_LocalIPOverride = string.Empty;
@@ -149,7 +151,8 @@ namespace E3Core.Settings
             LoadKeyData("General", "LazarusManaRecovery (On/Off)", parsedData, ref General_LazarusManaRecovery);
             LoadKeyData("General", "ExternalIP To Query For Local Address (8.8.8.8 default)", parsedData, ref General_Networking_ExternalIPToQueryForLocal);
             LoadKeyData("General", "Local IP Override", parsedData, ref General_Networking_LocalIPOverride);
-
+            LoadKeyData("General", "Delay After Short CastTime", parsedData, ref General_DelayAfterShortCastTime);
+            LoadKeyData("General", "Delay After Long CastTime", parsedData, ref General_DelayAfterLongCastTime);
             if (!IPAddress.TryParse(General_Networking_ExternalIPToQueryForLocal,out var result))
             {
                 General_Networking_ExternalIPToQueryForLocal = "8.8.8.8";
@@ -331,6 +334,10 @@ namespace E3Core.Settings
             section.Keys.AddKey("E3NetworkAddPathToMonitor", "");
         	section.Keys.AddKey("LazarusManaRecovery (On/Off)", "On");
 			section.Keys.AddKey("ExternalIP To Query For Local Address (8.8.8.8 default)", "8.8.8.8");
+            section.Keys.AddKey("Delay after Short CastTime", "300");
+            section.Keys.AddKey("Delay after Long CastTime", "500");
+
+
 
 			section.Keys.AddKey("Heal While Navigating (On/Off)","On");
             section.Keys.AddKey("Cure While Navigating (On/Off)", "On");


### PR DESCRIPTION
I thought adding these as configuration vars may be nice. One guildmate has reduced his berserker burns from taking 15s to 5s to fire by reducing the MQ.Delay(300) -> MQ.Delay(100) (E3.GeneralSettings.General_DelayAfterShortCastTime). 

It's definitely one of those things people will want to tweak for burns, but also could lead to bad things if they reduce delays by too much.