### PR TITLE
Add Global Cursor Delete

### DIFF
--- a/E3Next/E3.cs
+++ b/E3Next/E3.cs
@@ -236,7 +236,18 @@ namespace E3Core.Processors
                 E3.Bots.Broadcast("\aoComplete!");
                
             }
-			
+
+            if (GlobalCursorDelete.ShouldReload())
+            {
+                E3.Bots.Broadcast("\aoAuto-Reloading Global Cursor Delete/Character settings settings file...");
+                E3.GlobalCursorDelete = new GlobalCursorDelete();
+                CharacterSettings = new CharacterSettings();
+                Loot.Reset();
+                GiveMe.Reset();
+                Bard.RestartMelody();
+                E3.Bots.Broadcast("\aoComplete!");
+            }
+
             if (GeneralSettings.ShouldReload())
             {
                 E3.Bots.Broadcast("\aoAuto-Reloading General settings file...");
@@ -481,6 +492,7 @@ namespace E3Core.Processors
                     //}
                 }
 				GlobalIfs = new GlobalIfs();
+				GlobalCursorDelete = new GlobalCursorDelete();
 				CharacterSettings = new Settings.CharacterSettings();
                 AdvancedSettings = new Settings.AdvancedSettings();
 				
@@ -541,6 +553,7 @@ namespace E3Core.Processors
         public static Logging Log = Core.logInstance;
         public static Settings.CharacterSettings CharacterSettings = null;
 		public static Settings.FeatureSettings.GlobalIfs GlobalIfs = null;
+		public static Settings.FeatureSettings.GlobalCursorDelete GlobalCursorDelete = null;
 		public static Settings.GeneralSettings GeneralSettings = null;
         public static Settings.AdvancedSettings AdvancedSettings = null;
         public static IBots Bots = null;

--- a/E3Next/E3Next.csproj
+++ b/E3Next/E3Next.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Processors\Rez.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings\FeatureSettings\DoorDataFile.cs" />
+    <Compile Include="Settings\FeatureSettings\GlobalCursorDelete.cs" />
     <Compile Include="Settings\FeatureSettings\GlobalIfs.cs" />
     <Compile Include="Settings\FeatureSettings\LazarusSymbolDataFile.cs" />
     <Compile Include="Settings\FeatureSettings\LootDataFile.cs" />

--- a/E3Next/Processors/Basics.cs
+++ b/E3Next/Processors/Basics.cs
@@ -1851,7 +1851,8 @@ namespace E3Core.Processors
 
                     //auto delete stuff on cursor that is configured to do so
                     string autoinvItem = MQ.Query<string>("${Cursor}");
-                    if (E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
+                    if (E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase) || 
+                        E3.GlobalCursorDelete.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
                     {
 						//configured to delete this item.
 						e3util.CursorTryDestroyItem(autoinvItem);
@@ -1892,7 +1893,8 @@ namespace E3Core.Processors
                 {
                     //auto delete stuff on cursor that is configured to do so
                     string autoinvItem = MQ.Query<string>("${Cursor}");
-                    if (E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
+                    if (E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase) ||
+                        E3.GlobalCursorDelete.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
                     {
 						//configured to delete this item.
 						e3util.CursorTryDestroyItem(autoinvItem);

--- a/E3Next/Settings/FeatureSettings/GlobalCursorDelete.cs
+++ b/E3Next/Settings/FeatureSettings/GlobalCursorDelete.cs
@@ -1,0 +1,87 @@
+﻿using E3Core.Utility;
+using IniParser;
+using IniParser.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace E3Core.Settings.FeatureSettings
+{
+    public class GlobalCursorDelete : BaseSettings, IBaseSettings
+    {
+        private string _filename = String.Empty;
+        public List<String> Cursor_Delete = new List<string>();
+
+        public GlobalCursorDelete()
+        {
+            LoadData();
+        }
+        
+        public void LoadData()
+        {
+            _filename = GetSettingsFilePath("GlobalCursorDelete.ini");
+            if (!String.IsNullOrEmpty(CurrentSet))
+            {
+                _filename = _filename.Replace(".ini", "_" + CurrentSet + ".ini");
+            }
+            IniData parsedData;
+            FileIniDataParser fileIniData = e3util.CreateIniParser();
+            
+            if (!System.IO.File.Exists(_filename))
+            {
+                if (!System.IO.Directory.Exists(_configFolder + _settingsFolder))
+                {
+                    System.IO.Directory.CreateDirectory(_configFolder + _settingsFolder);
+                }
+
+                parsedData = CreateSettings(_filename);
+            }
+            else
+            {
+                parsedData = fileIniData.ReadFile(_filename);
+            }
+            
+            _fileLastModifiedFileName = _filename;
+            _fileLastModified = System.IO.File.GetLastWriteTime(_filename);
+            
+            //have the data now!
+            if (parsedData == null)
+            {
+                throw new Exception("Could not load Global Cursor Delete file");
+            }
+            
+            LoadKeyData("Cursor Delete", "Delete", parsedData, Cursor_Delete);
+        }
+        
+        public IniData CreateSettings(string filename)
+        {
+            IniParser.FileIniDataParser parser = e3util.CreateIniParser();
+            IniData newFile = new IniData();
+            
+            newFile.Sections.AddSection("Cursor Delete");
+            var section = newFile.Sections.GetSectionData("Cursor Delete");
+            
+            if (!System.IO.File.Exists(filename))
+            {
+                if (!System.IO.Directory.Exists(_configFolder + _settingsFolder))
+                {
+                    System.IO.Directory.CreateDirectory(_configFolder + _settingsFolder);
+                }
+                _log.Write($"Creating new Global Cursor Delete file:{filename}");
+                //file straight up doesn't exist, lets create it
+                parser.WriteFile(filename, newFile);
+            }
+            else
+            {
+                //some reason we were called when this already exists, just return what is there.
+                FileIniDataParser fileIniData = e3util.CreateIniParser();
+                IniData parsedData = fileIniData.ReadFile(filename);
+                
+                return parsedData;
+            }
+            
+            return newFile;
+        }
+    }
+}

--- a/E3Next/Utility/e3util.cs
+++ b/E3Next/Utility/e3util.cs
@@ -726,8 +726,9 @@ namespace E3Core.Utility
                 if (cursorID > 0)
                 {
                     string autoinvItem = MQ.Query<string>("${Cursor}");
-
-                    if(E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
+                    
+                    if (E3.CharacterSettings.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase) || 
+                        E3.GlobalCursorDelete.Cursor_Delete.Contains(autoinvItem, StringComparer.OrdinalIgnoreCase))
                     {
 						//configured to delete this item.
 						CursorTryDestroyItem(autoinvItem);


### PR DESCRIPTION
centralized location to handle cursor deletes instead of having to edit each bot ini individually.