### PR TITLE
CheckMana before CheckReady

### DIFF
--- a/E3Next/Classes/Bard.cs
+++ b/E3Next/Classes/Bard.cs
@@ -505,7 +505,7 @@ namespace E3Core.Classes
                     return;
                 }
             }
-            if (Casting.CheckReady(songToPlay) && Casting.CheckMana(songToPlay))
+            if (Casting.CheckMana(songToPlay) && Casting.CheckReady(songToPlay))
             {
                
                 MQ.Write($"\atTwist \ag{songToPlay.SpellName}");

--- a/E3Next/Classes/Magician.cs
+++ b/E3Next/Classes/Magician.cs
@@ -470,7 +470,7 @@ namespace E3Core.Classes
                     }
 
                     Int32 castAttempts = 0;
-                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                     {
                         while (Casting.Cast(petId, spell) == CastReturn.CAST_FIZZLE)
                         {
@@ -494,7 +494,7 @@ namespace E3Core.Classes
                         counter++;
                     }
 
-                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                     {
                         while (Casting.Cast(petId, spell) == CastReturn.CAST_FIZZLE)
                         {
@@ -719,7 +719,7 @@ namespace E3Core.Classes
                 counter++;
             }
 
-            if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+            if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
             {
                 int cursorId = 0;
                 // try several times to summon

--- a/E3Next/Classes/Necromancer.cs
+++ b/E3Next/Classes/Necromancer.cs
@@ -45,7 +45,7 @@ namespace E3Core.Classes
                         {
                             s = new Spell("Improved Death Peace");
                         }
-                        if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                        if (Casting.CheckMana(s) && Casting.CheckReady(s))
                         {
                             Casting.Cast(0, s);
                           
@@ -83,7 +83,7 @@ namespace E3Core.Classes
                 {
                     s = new Spell("Improved Death Peace");
                 }
-                if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                if (Casting.CheckMana(s) && Casting.CheckReady(s))
                 {
                     Casting.Cast(0, s);
                     FD = true;
@@ -151,7 +151,7 @@ namespace E3Core.Classes
 					{
 						s = new Spell("Improved Death Peace");
 					}
-					if (Casting.CheckReady(s) && Casting.CheckMana(s))
+					if (Casting.CheckMana(s) && Casting.CheckReady(s))
 					{
 						Casting.Cast(0, s);
 						//check to see if we can stand based off the # of group members.
@@ -179,7 +179,7 @@ namespace E3Core.Classes
                 {
                     s = new Spell("Death Peace");
                 }
-                if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                if (Casting.CheckMana(s) && Casting.CheckReady(s))
                 {
                     Casting.Cast(0, s);
                     //check to see if we can stand based off the # of group members.

--- a/E3Next/Classes/Ranger.cs
+++ b/E3Next/Classes/Ranger.cs
@@ -45,7 +45,7 @@ namespace E3Core.Classes
                     {
                         s = new Spell("Cover Tracks");
                     }
-                    if (MQ.Query<bool>("${Target.Named}") && Casting.CheckReady(s) && Casting.CheckMana(s))
+                    if (MQ.Query<bool>("${Target.Named}") && Casting.CheckMana(s) && Casting.CheckReady(s))
                     {
                         Casting.Cast(0, s);
                         return;

--- a/E3Next/Classes/Shaman.cs
+++ b/E3Next/Classes/Shaman.cs
@@ -186,7 +186,7 @@ namespace E3Core.Classes
                     {
                         s = new Spell("Inconspicuous Totem");
                     }
-                    if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                    if (Casting.CheckMana(s) && Casting.CheckReady(s))
                     {
                         Casting.Cast(0, s);
                         MQ.Delay(400);
@@ -233,7 +233,7 @@ namespace E3Core.Classes
                         {
                             s = new Spell($"{idolSpellName}/Gem|{E3.CharacterSettings.MalosTotemSpellGem}");
                         }
-                        if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                        if (Casting.CheckMana(s) && Casting.CheckReady(s))
                         {
                             Casting.Cast(0, s);
                             return;

--- a/E3Next/Processors/Basics.cs
+++ b/E3Next/Processors/Basics.cs
@@ -100,7 +100,7 @@ namespace E3Core.Processors
 								}
 							}
 
-							if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+							if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                             {
                                 Casting.Cast(E3.CurrentId, spell);
                             }
@@ -906,7 +906,7 @@ namespace E3Core.Processors
 							//don't try and mem a spell if its not already mem
 							if ((spell.CastType != CastingType.Spell) || !Casting.SpellInCooldown(spell))
                             {
-                                if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                                if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                                 {
                                     Casting.Cast(0, spell);
                                     return;
@@ -944,7 +944,7 @@ namespace E3Core.Processors
                             {
                                 s = new Spell(spellToCheck);
                             }
-                            if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                            if (Casting.CheckMana(s) && Casting.CheckReady(s))
                             {
                                 Casting.Cast(0, s);
                             }

--- a/E3Next/Processors/BegForBuffs.cs
+++ b/E3Next/Processors/BegForBuffs.cs
@@ -483,7 +483,7 @@ namespace E3Core.Processors
 					}
 					
 
-                    if ((s.TargetType=="Self" ||Casting.InRange(spawn.ID, s)) && Casting.CheckReady(s) && Casting.CheckMana(s))
+                    if ((s.TargetType=="Self" || Casting.InRange(spawn.ID, s)) && Casting.CheckMana(s) && Casting.CheckReady(s))
                     {
                         //so we can be sure our cursor was empty before we cast
                         Int32 cursorID = MQ.Query<Int32>("${Cursor.ID}");

--- a/E3Next/Processors/BuffCheck.cs
+++ b/E3Next/Processors/BuffCheck.cs
@@ -621,7 +621,7 @@ namespace E3Core.Processors
 					if (!(hasBuff || hasSong))
 					{
 						bool willStack = MQ.Query<bool>($"${{Spell[{spell.SpellName}].WillLand}}");
-						if (willStack && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+						if (willStack && Casting.CheckMana(spell) && Casting.CheckReady(spell))
 						{
 							if (spell.TargetType == "Self" || spell.TargetType == "Group v1")
 							{
@@ -770,7 +770,7 @@ namespace E3Core.Processors
 								continue;
 							}
 							bool willStack = MQ.Query<bool>($"${{Spell[{spell.SpellName}].WillLand}}");
-							if (willStack && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+							if (willStack && Casting.CheckMana(spell) && Casting.CheckReady(spell))
 							{
 								CastReturn result;
 								recastSpell:
@@ -847,7 +847,7 @@ namespace E3Core.Processors
 							}
 							bool willStack = MQ.Query<bool>($"${{Spell[{spell.SpellName}].WillLandPet}}");
 							recastSpell:
-							if (willStack && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+							if (willStack && Casting.CheckMana(spell) && Casting.CheckReady(spell))
 							{
 								CastReturn result;
 
@@ -950,7 +950,7 @@ namespace E3Core.Processors
 									continue;
 								}
 								recastSpell:
-								if (willStack && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+								if (willStack && Casting.CheckMana(spell) && Casting.CheckReady(spell))
 								{
 
 									//E3.Bots.Broadcast($"{spell.CastTarget} is missing the buff {spell.CastName} with id:{spell.SpellID}. current list:{String.Join(",",list)}");
@@ -1049,7 +1049,7 @@ namespace E3Core.Processors
 
 									//not one of our buffs uhh, try and cast and see if we get a non success message.
 									recastSpell:
-									if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+									if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 									{
 										var result = Casting.Cast(s.ID, spell);
 
@@ -1084,7 +1084,7 @@ namespace E3Core.Processors
 									if (timeLeftInMS < 15000)
 									{
 										recastSpell:
-										if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+										if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 										{
 											var result = Casting.Cast(s.ID, spell);
 											if (result == CastReturn.CAST_FIZZLE)
@@ -1463,7 +1463,7 @@ namespace E3Core.Processors
 				if (_selectAura.CastType == CastingType.Spell)
 				{
 					//this is a spell, need to mem, then cast. 
-					if (Casting.CheckReady(_selectAura) && Casting.CheckMana(_selectAura))
+					if (Casting.CheckMana(_selectAura) && Casting.CheckReady(_selectAura))
 					{
 						Casting.Cast(meID, _selectAura);
 					}

--- a/E3Next/Processors/Casting.cs
+++ b/E3Next/Processors/Casting.cs
@@ -1005,7 +1005,7 @@ namespace E3Core.Processors
 						if (maxTries > 40) break;
 					}
 				}
-				if (CheckReady(spell.AfterSpellData) && CheckMana(spell.AfterSpellData))
+				if (CheckMana(spell.AfterSpellData) && CheckReady(spell.AfterSpellData))
 				{
 				retrycast:
 					Int32 retryCounter = 0;
@@ -1044,7 +1044,7 @@ namespace E3Core.Processors
 						if (maxTries > 40) break;
 					}
 				}
-				if (CheckReady(spell.BeforeSpellData) && CheckMana(spell.BeforeSpellData))
+				if (CheckMana(spell.BeforeSpellData) && CheckReady(spell.BeforeSpellData))
 				{
 				retrycast:
 					if (Casting.Cast(targetID, spell.BeforeSpellData) == CastReturn.CAST_FIZZLE)

--- a/E3Next/Processors/Cures.cs
+++ b/E3Next/Processors/Cures.cs
@@ -87,7 +87,7 @@ namespace E3Core.Processors
 							{
 								if (bufflist.Contains(spell.CheckForCollection[checkforItem]))
 								{
-									if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+									if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 									{
 										Casting.Cast(s.ID, spell);
 										return;
@@ -183,7 +183,7 @@ namespace E3Core.Processors
                                 }
                             }
                             if (foundBadBuff) continue;
-                            if (Casting.InRange(s.ID,spell) && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                            if (Casting.InRange(s.ID,spell) && Casting.CheckMana(spell) && Casting.CheckReady(spell))
                             {
                                 Casting.Cast(s.ID, spell);
                                 return true;
@@ -211,7 +211,7 @@ namespace E3Core.Processors
                         {
                             if(buffList.Contains(pair.Value))
                             {
-								if (Casting.InRange(s.ID, spell) && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+								if (Casting.InRange(s.ID, spell) && Casting.CheckMana(spell) && Casting.CheckReady(spell))
 								{
 									Casting.Cast(s.ID, spell);
 									return;

--- a/E3Next/Processors/DebuffDot.cs
+++ b/E3Next/Processors/DebuffDot.cs
@@ -444,7 +444,7 @@ namespace E3Core.Processors
 					}
 				}
 
-                if (Casting.InRange(mobid, spell) && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                if (Casting.InRange(mobid, spell) && Casting.CheckMana(spell) && Casting.CheckReady(spell))
                 {
 
                     //lets make sure the buffs/debuffs are there

--- a/E3Next/Processors/Dispel.cs
+++ b/E3Next/Processors/Dispel.cs
@@ -70,7 +70,7 @@ namespace E3Core.Processors
                                 foreach (var spell in E3.CharacterSettings.Dispels)
                                 {
                                     //now have it as a target, need to check its beneficial buffs
-                                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                                     {
                                         Casting.Cast(0, spell);
                                         return;

--- a/E3Next/Processors/GiveMe.cs
+++ b/E3Next/Processors/GiveMe.cs
@@ -360,7 +360,7 @@ namespace E3Core.Processors
                 Spell s;
                 if (_groupSpellRequests.TryGetValue(whatToGive, out s))
                 {
-                    if (Casting.CheckReady(s) && Casting.CheckMana(s))
+                    if (Casting.CheckMana(s) && Casting.CheckReady(s))
                     {
                         //lets tell everyone else to destroy their items and destroy our own.
                         E3.Bots.BroadcastCommandToGroup($"/DestroyNoRent \"{whatToGive}\"");
@@ -390,7 +390,7 @@ namespace E3Core.Processors
 				e3util.ClearCursor();
 				Int32 cursorID = MQ.Query<Int32>("${Cursor.ID}");
 
-				if (cursorID<1 && Casting.CheckReady(s) && Casting.CheckMana(s))
+				if (cursorID<1 && Casting.CheckMana(s) && Casting.CheckReady(s))
 				{
 				
 					e3util.DeleteNoRentItem(spellToUse);

--- a/E3Next/Processors/Heals.cs
+++ b/E3Next/Processors/Heals.cs
@@ -223,7 +223,7 @@ namespace E3Core.Processors
 						if (currentLowestHealth < spell.HealPct)
 						{
 							
-							if (Casting.CheckReady(spell,JustCheck,JustCheck) && Casting.CheckMana(spell))
+							if (Casting.CheckMana(spell) && Casting.CheckReady(spell,JustCheck,JustCheck))
 							{
 								if (JustCheck) return true;
 
@@ -438,7 +438,7 @@ namespace E3Core.Processors
 				{
 					continue;
 				}
-				if (Casting.CheckReady(spell, true, !CastIfNeed) && Casting.CheckMana(spell))
+				if (Casting.CheckMana(spell) && Casting.CheckReady(spell, true, !CastIfNeed))
 				{
 					if (pctHealth < spell.HealPct && pctHealth != 0)
 					{
@@ -500,7 +500,7 @@ namespace E3Core.Processors
 					{
 						continue;
 					}
-					if(Casting.CheckReady(spell, true, !CastIfNeeded) && Casting.CheckMana(spell))
+					if(Casting.CheckMana(spell) && Casting.CheckReady(spell, true, !CastIfNeeded))
 					{
 						if (pctHealth < spell.HealPct)
 						{
@@ -649,7 +649,7 @@ namespace E3Core.Processors
 													}
 												}
 												//should cast a heal!
-												if (Casting.CheckReady(spell, JustCheck, JustCheck) && Casting.CheckMana(spell))
+												if (Casting.CheckMana(spell) && Casting.CheckReady(spell, JustCheck, JustCheck))
 												{
 													if (JustCheck)
 													{
@@ -724,7 +724,7 @@ namespace E3Core.Processors
 										{
 										
 											//should cast a heal!
-											if (Casting.CheckReady(spell, JustCheck, JustCheck) && Casting.CheckMana(spell))
+											if (Casting.CheckMana(spell) && Casting.CheckReady(spell, JustCheck, JustCheck))
 											{
 												if (JustCheck)
 												{
@@ -851,7 +851,7 @@ namespace E3Core.Processors
 											if (pctHealth < spell.HealPct)
 											{
 												//should cast a heal!
-												if (Casting.CheckReady(spell, JustCheck, JustCheck) && Casting.CheckMana(spell))
+												if (Casting.CheckMana(spell) && Casting.CheckReady(spell, JustCheck, JustCheck))
 												{
 													if (JustCheck) return true;
 													if (Casting.Cast(targetID, spell) == CastReturn.CAST_FIZZLE)
@@ -970,7 +970,7 @@ namespace E3Core.Processors
 											{
 												if (!E3.Bots.HasShortBuff(name, spell.SpellID))
 												{
-													if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+													if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 													{
 														if (Casting.Cast(targetID, spell) == CastReturn.CAST_FIZZLE)
 														{
@@ -1011,7 +1011,7 @@ namespace E3Core.Processors
 							continue;
 						}
 					}
-					if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+					if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 					{
 						if (JustCheck) return true;
 						Int32 targetIDToUse = myID;

--- a/E3Next/Processors/NowCast.cs
+++ b/E3Next/Processors/NowCast.cs
@@ -214,10 +214,6 @@ namespace E3Core.Processors
 						}
 					}
 				recast:
-					if (!Casting.CheckReady(spell))
-                    {
-                        return (CastReturn.CAST_NOTREADY,spell);
-                    }
                     if(!Casting.InRange(targetid,spell))
                     {
                         return (CastReturn.CAST_OUTOFRANGE,spell);
@@ -226,6 +222,10 @@ namespace E3Core.Processors
 					{
 						return (CastReturn.CAST_OUTOFMANA,spell);
 					}
+					if (!Casting.CheckReady(spell))
+                    {
+                        return (CastReturn.CAST_NOTREADY,spell);
+                    }
                     if(targetid>0 && targetid!=E3.CurrentId)
                     {
 						Casting.TrueTarget(targetid);

--- a/E3Next/Processors/Nukes.cs
+++ b/E3Next/Processors/Nukes.cs
@@ -124,7 +124,7 @@ namespace E3Core.Processors
                                 }
                             }
                             //can't cast if it isn't ready
-                            if (Casting.InRange(Assist.AssistTargetID, spell) && Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                            if (Casting.InRange(Assist.AssistTargetID, spell) && Casting.CheckMana(spell) && Casting.CheckReady(spell))
                             {
                                 //we should have a valid target via check_assistStatus
                                 if (spell.Delay > 0 && delayTimeStamp > 0 && Core.StopWatch.ElapsedMilliseconds < delayTimeStamp)
@@ -228,7 +228,7 @@ namespace E3Core.Processors
                         }
                     }
                     //can't cast if it isn't ready
-                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                     {
                         //we should have a valid target via check_assistStatus
                         if (spell.Delay > 0 && delayTimeStamp > 0 && Core.StopWatch.ElapsedMilliseconds < delayTimeStamp)

--- a/E3Next/Processors/Pets.cs
+++ b/E3Next/Processors/Pets.cs
@@ -110,7 +110,7 @@ namespace E3Core.Processors
                         }
                     }
 
-                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                     {
                         Casting.Cast(0, spell);
                         castPet = true;
@@ -156,7 +156,7 @@ namespace E3Core.Processors
 				if (!spell.Enabled) continue;
 				if (pctHps <= spell.HealPct)
                 {
-                    if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                    if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                     {
                         Casting.Cast(petID, spell);
                         return;

--- a/E3Next/Processors/Rez.cs
+++ b/E3Next/Processors/Rez.cs
@@ -429,7 +429,7 @@ namespace E3Core.Processors
 								}
 							}
 
-							if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+							if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                             {
                                 if (Basics.InCombat())
                                 {
@@ -531,7 +531,7 @@ namespace E3Core.Processors
 
 					foreach (var spell in _currentRezSpells)
                     {
-                        if (Casting.CheckReady(spell) && Casting.CheckMana(spell) && CanRez())
+                        if (CanRez() && Casting.CheckMana(spell) && Casting.CheckReady(spell))
                         {
                             E3.Bots.Broadcast($"Rezing {s.DisplayName}");
                             Casting.Cast(s.ID, spell);
@@ -597,7 +597,7 @@ namespace E3Core.Processors
 					E3.Bots.Broadcast($"Rezing {s.DisplayName}");
 		            foreach (var spell in _currentRezSpells)
                     {
-                        if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                        if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
 						{
 							E3.Bots.Broadcast($"Trying to rez {s.DisplayName}");
 							MQ.Cmd("/corpse");
@@ -650,7 +650,7 @@ namespace E3Core.Processors
         {
             foreach (var spell in _currentRezSpells)
             {
-                if (Casting.CheckReady(spell) && Casting.CheckMana(spell))
+                if (Casting.CheckMana(spell) && Casting.CheckReady(spell))
                 {
                     return true;
                 }


### PR DESCRIPTION
per discord:

https://discord.com/channels/1156237787469709324/1156985692283486298/1314360098210185227

spells are getting memmed when they can't get cast due to low mana, resulting in mem-unmem cycles during buffing or similar

moved all CheckMana to before CheckReady

⚠️ TESTING IN PROGRESS ⚠️ 